### PR TITLE
Update URL for SElinux workaround for PowerFlex

### DIFF
--- a/osp-deploy/cinder/powerflex/README.md
+++ b/osp-deploy/cinder/powerflex/README.md
@@ -92,7 +92,7 @@ parameter_defaults:
 ```
 ### Workarounds
 
-Workaround for SElinux issue, see attached [SElinux_workaround_for_SDC_RHEL8.2.pdf](https://github.com/dell/osp-integration/edit/master/osp-deploy/cinder/powerflex/SElinux_workaround_for_SDC_RHEL8.2.pdf).
+Workaround for SElinux issue, see attached [SElinux_workaround_for_SDC_RHEL8.2.pdf](https://github.com/dell/osp-integration/blob/master/osp-deploy/cinder/powerflex/SElinux_workaround_for_SDC_RHEL8.2.pdf).
 
 
 ### Deploy the configured backends


### PR DESCRIPTION
URL linking to SElinux_workaround_for_SDC_RHEL8.2.pdf is actually directing users to edit, which causes issues if they don't have access to the repository already or haven't already forked it. Changing path from edit to blob meaning anyone can view the PDF without errors.