### PR TITLE
Powerflex 3.6 guide rhosp17.1

### DIFF
--- a/osp-deploy/cinder/powerflex/README.md
+++ b/osp-deploy/cinder/powerflex/README.md
@@ -158,7 +158,7 @@ san_password = powerflex_password
 Install the PowerFlex Storage Data Client (SDC) on all nodes after deploying the overcloud.
 
 ### Test the configured Backend
-Finally, create a Powerflex volume type and test if you can successfully create and attach volumes of that type.
+Finally, create a PowerFlex volume type and test if you can successfully create and attach volumes of that type.
 
 Run the following command to check whether the Cinder service is started. 
 ```

--- a/osp-deploy/cinder/powerflex/README.md
+++ b/osp-deploy/cinder/powerflex/README.md
@@ -13,8 +13,8 @@ For more information please refer to [Product Documentation for Red Hat OpenStac
 ## Prerequisites
 
 - Red Hat OpenStack Platform 17.1 with RHEL 9.2.
-- PowerFlex 3.5 or 3.6
-- PowerFlex Storage Data Client (SDC) has to be installed on all OpenStack nodes.
+- PowerFlex 3.5 or 3.6 cluster.
+- PowerFlex Storage Data Client (SDC) for RHEL9.2.
 
 ## Steps
 
@@ -155,10 +155,24 @@ san_password = powerflex_password
 
 ### Install SDC
 
-Install the Storage Data Client (SDC) on all nodes after deploying the overcloud
+Install the PowerFlex Storage Data Client (SDC) on all nodes after deploying the overcloud.
 
 ### Test the configured Backend
-Finally create a volume-type and test if you can successfully create and attach volumes of that type.
+Finally, create a Powerflex volume type and test if you can successfully create and attach volumes of that type.
 
-
-
+Run the following command to check whether the Cinder service is started. 
+```
+[stack@rhosp-undercloud ~]$ source ~/overcloudrc
+(overcloud) [stack@rhosp-undercloud ~]$ cinder service-list
+```
+Run the following command in RHOSP Director to create a volume type mapped to the deployed backend.
+```
+[stack@rhosp-undercloud ~]$ source ~/overcloudrc
+(overcloud) [stack@rhosp-undercloud ~]$ cinder type-create powerflex1
+(overcloud) [stack@rhosp-undercloud ~]$ cinder type-key powerflex1 set volume_backend_name=tripleo_dellemc_powerflex
+```
+Create a volume using the type created above without error to ensure the availability of the backend.
+```
+[stack@rhosp-undercloud ~]$ source ~/overcloudrc
+(overcloud) [stack@rhosp-undercloud ~]$ cinder create --volume-type powerflex1 --size 8 powerflex_volume1
+```

--- a/osp-deploy/cinder/powerflex/README.md
+++ b/osp-deploy/cinder/powerflex/README.md
@@ -163,16 +163,16 @@ Finally, create a PowerFlex volume type and test if you can successfully create 
 Run the following command to check whether the Cinder service is started. 
 ```
 [stack@rhosp-undercloud ~]$ source ~/overcloudrc
-(overcloud) [stack@rhosp-undercloud ~]$ cinder service-list
+(overcloud) [stack@rhosp-undercloud ~]$ openstack volume service list
 ```
 Run the following command in RHOSP Director to create a volume type mapped to the deployed backend.
 ```
 [stack@rhosp-undercloud ~]$ source ~/overcloudrc
-(overcloud) [stack@rhosp-undercloud ~]$ cinder type-create powerflex1
-(overcloud) [stack@rhosp-undercloud ~]$ cinder type-key powerflex1 set volume_backend_name=tripleo_dellemc_powerflex
+(overcloud) [stack@rhosp-undercloud ~]$ openstack volume type create powerflex1
+(overcloud) [stack@rhosp-undercloud ~]$ openstack volume type set --property volume_backend_name=tripleo_dellemc_powerflex powerflex1
 ```
 Create a volume using the type created above without error to ensure the availability of the backend.
 ```
 [stack@rhosp-undercloud ~]$ source ~/overcloudrc
-(overcloud) [stack@rhosp-undercloud ~]$ cinder create --volume-type powerflex1 --size 8 powerflex_volume1
+(overcloud) [stack@rhosp-undercloud ~]$ openstack volume create --type powerflex1 --size 8 powerflex_volume1
 ```

--- a/osp-deploy/cinder/powerflex/README.md
+++ b/osp-deploy/cinder/powerflex/README.md
@@ -14,9 +14,7 @@ For more information please refer to [Product Documentation for Red Hat OpenStac
 
 - Red Hat OpenStack Platform 17.1 with RHEL 9.2.
 - PowerFlex 3.5 or 3.6
-- PowerFlex Gateway has to be installed and accessible in the network.
 - PowerFlex Storage Data Client (SDC) has to be installed on all OpenStack nodes.
-- Configuration settings and credentials of Gateway.
 
 ## Steps
 
@@ -161,4 +159,6 @@ Install the Storage Data Client (SDC) on all nodes after deploying the overcloud
 
 ### Test the configured Backend
 Finally create a volume-type and test if you can successfully create and attach volumes of that type.
+
+
 


### PR DESCRIPTION
Made some modifications based on Redhat's feedback to meet Redhat requirements.

1. Since PowerFlex Gateway is a PowerFlex cluster-side configuration, installation and configuration are not required in RHOSP. Remove the Gateway content to avoid misunderstandings.
2. Add some verification commands in the verification section