### PR TITLE
Changed as per RH suggestions

### DIFF
--- a/RHOSO-18.0/cinder/powerflex/README.md
+++ b/RHOSO-18.0/cinder/powerflex/README.md
@@ -198,6 +198,9 @@ edpm_nova_extra_bind_mounts:
     dest: /opt/emc/scaleio/openstack/connector.conf
     options: "ro"
 ```
+```
+Note: The same powerflex-connector secret can be used with the ExtraMount so the nova-compute pod has access to the connector.conf file. This would eliminate the need to manually configure the file on the host.
+```
 
 Create PowerFlex connector secret 
 ```yaml

--- a/RHOSO-18.0/cinder/powerflex/README.md
+++ b/RHOSO-18.0/cinder/powerflex/README.md
@@ -51,11 +51,9 @@ oc describe secret/cinder-volume-powerflex-secrets
 ```
 For full detailed instruction of all options please refer to [PowerFlex Backend Configuration](https://docs.openstack.org/cinder/2023.1/configuration/block-storage/drivers/dell-emc-powerflex-driver.html).
 
-* Edit the existing OpenStackControlPlane CR
-```
-oc edit openstackcontrolplane
-```
-Modify the cinderVolumes section as follows
+* In the OpenStackControlPlane CR, esnure you have the below section
+
+Use the cinderVolumes section as follows
 ```
 ...
 cinderVolumes:
@@ -75,7 +73,11 @@ cinderVolumes:
           resources: {}
 ...
 ```
-Save and exit the file, the prompt tells you that the CR was edited. Verify the pod is running
+Save and exit the file. Apply the CR. 
+```
+oc apply -f openstackcontrolplane.yaml
+```
+Verify the pod is running
 
 ```
 oc get pods -n openstack | grep powerflex
@@ -215,7 +217,7 @@ stringData:
 type: Opaque
 ```
 
-Edit the existing OpenStackControlPlane CR and add an extraMount specification as follows
+In the OpenStackControlPlane CR and add an extraMount specification as follows
 ```
 ...  
 spec:


### PR DESCRIPTION
Changed as per RH suggestions

- Instead of dynamically modifying the control plane using "oc edit openstackcontrolplane" the instructions should follow the RHOSO deployment guide's approach, which is to edit the openstack_control_plane.yaml file and then "oc apply" the file. That way the YAML file is kept up to date, and dynamically applied settings aren't lost the next time someone applies the YAML file.


- It should also be possible to use the same powerflex-connector secret with the ExtraMount so the nova-compute pod has access to the connector.conf file. This would eliminate the need to manually configure the file on the host, which is also a less secure way of handling the sensitive data. (Just add a note)
